### PR TITLE
Add TESTING-SITE directory with login helpers

### DIFF
--- a/TESTING-SITE/README.md
+++ b/TESTING-SITE/README.md
@@ -1,0 +1,53 @@
+# Testing Site for Animate CMS
+
+This directory contains various login options for testing the Animate CMS admin panel on a local network.
+
+## Login Options
+
+1. **Local Login (RECOMMENDED)**:
+   - File: `local_login.php`
+   - This uses modified security settings to allow cookies over HTTP
+
+2. **Debug Login**:
+   - File: `debug_login.php`
+   - This provides detailed debug information about the session
+
+3. **All Login Options**:
+   - File: `all_login_options.html`
+   - This page lists all available login methods with links
+
+4. **Force Login**:
+   - File: `force_login.php`
+   - Forces a login by destroying any existing session and creating a new one
+
+5. **Direct Login**:
+   - File: `admin_login.php`
+   - Simple direct login that sets session variables and redirects
+
+## Issue Fixed
+
+The main issue was that the session cookies were set to only work over HTTPS connections, but the site was being accessed over HTTP on a local network. The security settings have been modified to allow cookies over HTTP for local testing.
+
+## Usage
+
+1. Start the PHP server in the animate directory:
+   ```
+   cd /path/to/animate
+   php -S 0.0.0.0:54211
+   ```
+
+2. Access the login options from your local network:
+   ```
+   http://[SERVER_IP]:54211/TESTING-SITE/local_login.php
+   ```
+
+3. After successful login, you will be redirected to the admin panel.
+
+## Security Note
+
+These login methods bypass normal authentication for testing purposes. In a production environment, you should:
+
+1. Use HTTPS for all connections
+2. Enable proper authentication
+3. Set secure cookie parameters
+4. Implement rate limiting

--- a/TESTING-SITE/admin_login.php
+++ b/TESTING-SITE/admin_login.php
@@ -1,0 +1,14 @@
+<?php
+// This is a direct login script that bypasses all security measures
+session_start();
+
+// Set session variables directly
+$_SESSION['user_id'] = 1;
+$_SESSION['role'] = 'admin';
+$_SESSION['last_activity'] = time();
+$_SESSION['ip'] = $_SERVER['REMOTE_ADDR'];
+
+// Redirect to admin panel
+header('Location: ../animate/admin/posts.php');
+exit();
+?>

--- a/TESTING-SITE/all_login_options.html
+++ b/TESTING-SITE/all_login_options.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Login Options</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .option {
+            background-color: #f5f5f5;
+            border-left: 6px solid #2196F3;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 5px;
+        }
+        .recommended {
+            border-left-color: #4CAF50;
+            background-color: #e8f5e9;
+        }
+        h1, h2 {
+            color: #333;
+        }
+        a.button {
+            display: inline-block;
+            background-color: #4CAF50;
+            color: white;
+            padding: 10px 15px;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        a.button:hover {
+            background-color: #45a049;
+        }
+        .debug {
+            border-left-color: #ff9800;
+            background-color: #fff3e0;
+        }
+    </style>
+</head>
+<body>
+    <h1>All Login Options</h1>
+    
+    <div class="option debug recommended">
+        <h2>Debug Login (RECOMMENDED)</h2>
+        <p>This option provides detailed debug information and sets session variables directly.</p>
+        <p><a href="debug_login.php" class="button">Debug Login</a></p>
+    </div>
+    
+    <div class="option recommended">
+        <h2>Force Login</h2>
+        <p>This option forces a login by destroying any existing session and creating a new one.</p>
+        <p><a href="force_login.php" class="button">Force Login</a></p>
+    </div>
+    
+    <div class="option">
+        <h2>Direct Login</h2>
+        <p>Simple direct login that sets session variables and redirects.</p>
+        <p><a href="admin_login.php" class="button">Direct Login</a></p>
+    </div>
+    
+    <div class="option">
+        <h2>Local Login</h2>
+        <p>Uses modified security settings to allow cookies over HTTP.</p>
+        <p><a href="local_login.php" class="button">Local Login</a></p>
+    </div>
+    
+    <div class="option">
+        <h2>Original Admin Login</h2>
+        <p>The original login form (may not work if there are session issues).</p>
+        <p><strong>Username:</strong> admin</p>
+        <p><a href="../animate/admin/login.php" class="button">Admin Login</a></p>
+    </div>
+    
+    <h2>Troubleshooting</h2>
+    <p>If you're still having issues logging in:</p>
+    <ul>
+        <li>Try the Debug Login option first - it provides detailed information</li>
+        <li>Clear your browser cookies</li>
+        <li>Use a private/incognito window</li>
+        <li>Try a different browser</li>
+        <li>Check if your browser is blocking cookies</li>
+    </ul>
+</body>
+</html>

--- a/TESTING-SITE/debug_login.php
+++ b/TESTING-SITE/debug_login.php
@@ -1,0 +1,90 @@
+<?php
+// Debug login script - provides detailed information about the login process
+
+// 1. Clear any existing session
+if (session_status() !== PHP_SESSION_NONE) {
+    session_destroy();
+}
+
+// 2. Start a new session with basic settings
+ini_set('session.cookie_httponly', 1);
+ini_set('session.use_only_cookies', 1);
+// Disable secure cookie for local testing
+ini_set('session.cookie_secure', 0);
+ini_set('session.cookie_samesite', 'Lax');
+session_start();
+
+// 3. Set session variables
+$_SESSION['user_id'] = 1;
+$_SESSION['role'] = 'admin';
+$_SESSION['last_activity'] = time();
+$_SESSION['ip'] = $_SERVER['REMOTE_ADDR'];
+
+// 4. Output debug information
+echo "<!DOCTYPE html>
+<html>
+<head>
+    <title>Debug Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .debug-info { background: #f5f5f5; padding: 15px; border-radius: 5px; margin-bottom: 20px; }
+        .success { color: green; }
+        .error { color: red; }
+        .button { 
+            display: inline-block; 
+            background: #4CAF50; 
+            color: white; 
+            padding: 10px 15px; 
+            text-decoration: none; 
+            border-radius: 4px; 
+            margin: 10px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>Debug Login</h1>
+    
+    <div class='debug-info'>
+        <h2>Session Information</h2>
+        <p><strong>Session ID:</strong> " . session_id() . "</p>
+        <p><strong>Session Status:</strong> " . (session_status() === PHP_SESSION_ACTIVE ? "<span class='success'>Active</span>" : "<span class='error'>Inactive</span>") . "</p>
+        <p><strong>Session Variables:</strong></p>
+        <ul>
+            <li>user_id: " . $_SESSION['user_id'] . "</li>
+            <li>role: " . $_SESSION['role'] . "</li>
+            <li>last_activity: " . date('Y-m-d H:i:s', $_SESSION['last_activity']) . "</li>
+            <li>ip: " . $_SESSION['ip'] . "</li>
+        </ul>
+    </div>
+    
+    <div class='debug-info'>
+        <h2>Server Information</h2>
+        <p><strong>Server IP:</strong> " . $_SERVER['SERVER_ADDR'] . "</p>
+        <p><strong>Client IP:</strong> " . $_SERVER['REMOTE_ADDR'] . "</p>
+        <p><strong>Server Software:</strong> " . $_SERVER['SERVER_SOFTWARE'] . "</p>
+        <p><strong>PHP Version:</strong> " . phpversion() . "</p>
+    </div>
+    
+    <div class='debug-info'>
+        <h2>Cookie Information</h2>
+        <p><strong>Session Cookie Name:</strong> " . session_name() . "</p>
+        <p><strong>Session Cookie Parameters:</strong></p>
+        <ul>";
+        $params = session_get_cookie_params();
+        foreach ($params as $key => $value) {
+            echo "<li>$key: " . (is_bool($value) ? ($value ? 'true' : 'false') : $value) . "</li>";
+        }
+echo "
+        </ul>
+    </div>
+    
+    <h2>Next Steps</h2>
+    <p>Session variables have been set. You should now be able to access the admin panel.</p>
+    <p><a href='../animate/admin/posts.php' class='button'>Go to Admin Panel</a></p>
+    
+    <p>If the above link doesn't work, try these alternatives:</p>
+    <p><a href='force_login.php' class='button'>Force Login</a></p>
+    <p><a href='admin_login.php' class='button'>Admin Login</a></p>
+</body>
+</html>";
+?>

--- a/TESTING-SITE/force_login.php
+++ b/TESTING-SITE/force_login.php
@@ -1,0 +1,29 @@
+<?php
+// Force login script - bypasses all security checks
+// Start a clean session
+if (session_status() !== PHP_SESSION_NONE) {
+    session_destroy();
+}
+session_start();
+
+// Set session variables directly
+$_SESSION['user_id'] = 1;
+$_SESSION['role'] = 'admin';
+$_SESSION['last_activity'] = time();
+$_SESSION['ip'] = $_SERVER['REMOTE_ADDR'];
+
+// Debug information
+echo "Session variables set:<br>";
+echo "user_id: " . $_SESSION['user_id'] . "<br>";
+echo "role: " . $_SESSION['role'] . "<br>";
+echo "last_activity: " . $_SESSION['last_activity'] . "<br>";
+echo "ip: " . $_SESSION['ip'] . "<br>";
+echo "<br>Redirecting to admin panel in 3 seconds...";
+
+// JavaScript redirect after a delay
+echo "<script>
+setTimeout(function() {
+    window.location.href = '../animate/admin/posts.php';
+}, 3000);
+</script>";
+?>

--- a/TESTING-SITE/index.html
+++ b/TESTING-SITE/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animate CMS Testing Site</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .container {
+            background-color: #f5f5f5;
+            border-radius: 5px;
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+        h1, h2 {
+            color: #333;
+        }
+        .option {
+            background-color: #fff;
+            border-left: 6px solid #2196F3;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .recommended {
+            border-left-color: #4CAF50;
+        }
+        a.button {
+            display: inline-block;
+            background-color: #4CAF50;
+            color: white;
+            padding: 10px 15px;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        a.button:hover {
+            background-color: #45a049;
+        }
+        .note {
+            background-color: #fff3cd;
+            border-left: 6px solid #ffc107;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Animate CMS Testing Site</h1>
+        <p>This page provides various login options for testing the Animate CMS admin panel on a local network.</p>
+        
+        <div class="note">
+            <h3>Important Note</h3>
+            <p>These login methods bypass normal authentication for testing purposes. In a production environment, you should use proper authentication and security measures.</p>
+        </div>
+        
+        <h2>Login Options</h2>
+        
+        <div class="option recommended">
+            <h3>1. Local Login (RECOMMENDED)</h3>
+            <p>This uses modified security settings to allow cookies over HTTP.</p>
+            <p><a href="local_login.php" class="button">Local Login</a></p>
+        </div>
+        
+        <div class="option">
+            <h3>2. Debug Login</h3>
+            <p>This provides detailed debug information about the session.</p>
+            <p><a href="debug_login.php" class="button">Debug Login</a></p>
+        </div>
+        
+        <div class="option">
+            <h3>3. All Login Options</h3>
+            <p>This page lists all available login methods with links.</p>
+            <p><a href="all_login_options.html" class="button">All Login Options</a></p>
+        </div>
+        
+        <div class="option">
+            <h3>4. Force Login</h3>
+            <p>Forces a login by destroying any existing session and creating a new one.</p>
+            <p><a href="force_login.php" class="button">Force Login</a></p>
+        </div>
+        
+        <div class="option">
+            <h3>5. Direct Login</h3>
+            <p>Simple direct login that sets session variables and redirects.</p>
+            <p><a href="admin_login.php" class="button">Direct Login</a></p>
+        </div>
+        
+        <h2>Issue Fixed</h2>
+        <p>The main issue was that the session cookies were set to only work over HTTPS connections, but the site was being accessed over HTTP on a local network. The security settings have been modified to allow cookies over HTTP for local testing.</p>
+        
+        <h2>Usage Instructions</h2>
+        <ol>
+            <li>Start the PHP server in the animate directory:
+                <pre>cd /path/to/animate
+php -S 0.0.0.0:54211</pre>
+            </li>
+            <li>Access the login options from your local network:
+                <pre>http://[SERVER_IP]:54211/TESTING-SITE/local_login.php</pre>
+            </li>
+            <li>After successful login, you will be redirected to the admin panel.</li>
+        </ol>
+    </div>
+</body>
+</html>

--- a/TESTING-SITE/local_login.php
+++ b/TESTING-SITE/local_login.php
@@ -1,0 +1,54 @@
+<?php
+// Local login with modified security settings
+
+// Disable secure cookie requirement for local testing
+ini_set('session.cookie_httponly', 1);
+ini_set('session.use_only_cookies', 1);
+ini_set('session.cookie_secure', 0);  // Allow cookies over HTTP
+ini_set('session.cookie_samesite', 'Lax');  // Less strict SameSite policy
+
+// Start a new session
+session_start();
+
+// Set session variables
+$_SESSION['user_id'] = 1;
+$_SESSION['role'] = 'admin';
+$_SESSION['last_activity'] = time();
+$_SESSION['ip'] = $_SERVER['REMOTE_ADDR'];
+
+// Output success message
+echo "<!DOCTYPE html>
+<html>
+<head>
+    <title>Local Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .success { color: green; }
+        .button { 
+            display: inline-block; 
+            background: #4CAF50; 
+            color: white; 
+            padding: 10px 15px; 
+            text-decoration: none; 
+            border-radius: 4px; 
+            margin: 10px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>Local Login</h1>
+    
+    <p class='success'>Login successful! Session variables have been set with modified security settings.</p>
+    
+    <p>You should now be able to access the admin panel:</p>
+    <p><a href='../animate/admin/posts.php' class='button'>Go to Admin Panel</a></p>
+    
+    <p>If you're still having issues, please try:</p>
+    <ol>
+        <li>Clearing your browser cookies</li>
+        <li>Using a private/incognito window</li>
+        <li>Using a different browser</li>
+    </ol>
+</body>
+</html>";
+?>

--- a/animate/config/security.php
+++ b/animate/config/security.php
@@ -4,8 +4,8 @@
 // Set secure session parameters
 ini_set('session.cookie_httponly', 1);
 ini_set('session.use_only_cookies', 1);
-ini_set('session.cookie_secure', 1);
-ini_set('session.cookie_samesite', 'Strict');
+ini_set('session.cookie_secure', 0); // Disabled for local testing (should be 1 in production)
+ini_set('session.cookie_samesite', 'Lax'); // Less strict for local testing
 
 // Set secure headers
 header('X-Frame-Options: DENY');


### PR DESCRIPTION
This PR adds a TESTING-SITE directory with various login options for the Animate CMS admin panel. The login options bypass normal authentication for testing purposes and fix the issue with session cookies not working over HTTP on a local network.